### PR TITLE
chore: remove Renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@cybozu"
-  ]
-}


### PR DESCRIPTION
We have migrated this repository into `kintone/js-sdk`, so we no longer need Renovate in this repository.